### PR TITLE
Instead of getting the default post order, order by full name.

### DIFF
--- a/_includes/team-members-en.html
+++ b/_includes/team-members-en.html
@@ -1,5 +1,6 @@
 <div class="section-team__grid">
-{% for person in site.categories.time reversed %}
+{% assign sorted_team = site.categories.time | sort:"full_name" %}
+{% for person in sorted_team %}
   <div class="section-team__item">
     {% if person.en %}
       <a href="{{ person.en }}" title="{{ person.full_name }}">

--- a/_includes/team-members.html
+++ b/_includes/team-members.html
@@ -1,5 +1,6 @@
 <div class="section-team__grid">
-{% for person in site.categories.time reversed %}
+{% assign sorted_team = site.categories.time | sort:"full_name" %}
+{% for person in sorted_team %}
   <div class="section-team__item">
     {% if person.permalink %}
       <a href="{{ person.permalink }}" title="{{ person.full_name }}">


### PR DESCRIPTION
I was being shown right after Lucas because the post was named lunks.
Now I'm showing up in the correct place.